### PR TITLE
apps/user: add exclude_private_projects parameter to get_projects_fol…

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -125,13 +125,13 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['username']
 
-    def get_projects_follow_list(self):
+    def get_projects_follow_list(self, exclude_private_projects=False):
         projects = Project.objects \
             .filter(follow__creator=self,
                     follow__enabled=True,
-                    is_draft=False) \
-            .filter(models.Q(access=Access.PUBLIC) |
-                    models.Q(access=Access.SEMIPUBLIC))
+                    is_draft=False)
+        if exclude_private_projects:
+            projects = projects.exclude(models.Q(access=Access.PRIVATE))
 
         now = timezone.now()
 

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,9 +1,6 @@
-from django.db.models import Q
 from django.views.generic.detail import DetailView
 
 from adhocracy4.actions.models import Action
-from adhocracy4.projects.enums import Access
-from adhocracy4.projects.models import Project
 from apps.organisations.models import Organisation
 
 from . import models
@@ -14,18 +11,9 @@ class ProfileView(DetailView):
     slug_field = 'username'
 
     @property
-    def projects(self):
-        return Project.objects \
-            .filter(follow__creator=self.object,
-                    follow__enabled=True,
-                    is_draft=False) \
-            .filter(Q(access=Access.PUBLIC) |
-                    Q(access=Access.SEMIPUBLIC))
-
-    @property
     def projects_carousel(self):
         sorted_active_projects, sorted_future_projects, sorted_past_projects =\
-            self.object.get_projects_follow_list()
+            self.object.get_projects_follow_list(exclude_private_projects=True)
         return (list(sorted_active_projects) +
                 list(sorted_future_projects))[:9]
 


### PR DESCRIPTION
…low_list

In project carousel in userdashboard overview, only running and future modules are shown (as in user profile), past projects can be viewed by clicking on 'view all'. Not sure if this is what we want, couldnt really tell from the story description?

The sorting is still a thing, especially when viewing all projects, they are not sorted at all.. left it like this for now, because we have to  find an overall solution.