### PR TITLE
Kl 2021 04 follow overview

### DIFF
--- a/apps/userdashboard/views.py
+++ b/apps/userdashboard/views.py
@@ -55,7 +55,8 @@ class UserDashboardOverviewView(UserDashboardBaseMixin):
         sorted_active_projects, sorted_future_projects, sorted_past_projects =\
             self.request.user.get_projects_follow_list()
         return (list(sorted_active_projects) +
-                list(sorted_future_projects))[:9]
+                list(sorted_future_projects) +
+                list(sorted_past_projects))[:8]
 
 
 class UserDashboardActivitiesView(UserDashboardBaseMixin):

--- a/apps/users/templates/a4_candy_users/user_detail.html
+++ b/apps/users/templates/a4_candy_users/user_detail.html
@@ -104,7 +104,7 @@
                 {% if view.projects_carousel %}
                 <div class="project-tile-carousel">
                     {% for project in view.projects_carousel %}
-                        {% include 'a4_candy_projects/includes/project_tile_userprofile.html' with project=project orientation='vertical' %}
+                        {% include 'a4_candy_projects/includes/project_list_tile.html' with project=project orientation='vertical' %}
                     {% endfor %}
                 </div>
                 {% else %}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -15,7 +15,8 @@ class ProfileView(DetailView):
         sorted_active_projects, sorted_future_projects, sorted_past_projects =\
             self.object.get_projects_follow_list(exclude_private_projects=True)
         return (list(sorted_active_projects) +
-                list(sorted_future_projects))[:6]
+                list(sorted_future_projects) +
+                list(sorted_past_projects))[:6]
 
     @property
     def organisations(self):


### PR DESCRIPTION
The first commit fixes what I didn't notice when I merged #106 
I don't know if that tile was also meant to be replaced, though. @phillimorland do you? Was it meant for both the user dashboard overview and the user profile? And should both only display 6 tiles?