### PR TITLE
Ks 2021 04 add use ai setting

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -544,3 +544,4 @@ SITE_ID = 1 # overwrite this in local.py if needed
 
 AI_API_AUTH_TOKEN = ''
 AI_API_URL = 'https://kosmo-api-dev.liqd.net/api/classify/'
+AI_USAGE = True

--- a/tests/classifications/test_classification_signals.py
+++ b/tests/classifications/test_classification_signals.py
@@ -12,4 +12,4 @@ def test_ai_classification_receives_post_save_comment_signal(idea,
     assert(get_ai_classification in signals.post_save._live_receivers(Comment))
     comment_factory(content_object=idea,
                     comment='lala')
-    assert('Error connecting to %s' in str(caplog.records[-1]))
+    assert('No ai api auth token provided.' in str(caplog.records[-1]))


### PR DESCRIPTION
@fuzzylogic2000 I now set the default to not use the ai, thus I would then add it to local settings for dev on pillar to use the ai. Or do you prefer the other way around?

There is a PR for adding the setting on pillar: https://github.com/liqd/admin/pull/287