### PR TITLE
notification tests

### DIFF
--- a/apps/contrib/management/commands/send_test_emails.py
+++ b/apps/contrib/management/commands/send_test_emails.py
@@ -14,6 +14,7 @@ from adhocracy4.reports.models import Report
 from apps.cms.contacts.models import CustomFormSubmission
 from apps.cms.contacts.models import FormPage
 from apps.ideas.models import Idea
+from apps.moderatorfeedback.models import ModeratorCommentStatement
 from apps.notifications import emails as notification_emails
 from apps.offlineevents.models import OfflineEvent
 from apps.projects import emails as project_emails
@@ -66,7 +67,8 @@ class Command(BaseCommand):
         self._send_notification_event_upcoming()
         self._send_notification_phase()
         self._send_notification_project_created()
-        self._send_notifications_blocked_comment()
+        self._send_notification_blocked_comment()
+        self._send_notification_moderator_comment_statement()
 
         self._send_report_mails()
 
@@ -169,9 +171,12 @@ class Command(BaseCommand):
             NotifyInitiatorsOnProjectCreatedEmail.template_name
         )
 
-    def _send_notifications_blocked_comment(self):
+    def _send_notification_blocked_comment(self):
         # Send notification when comment is blocked
         comment = Comment.objects.first()
+        if not comment:
+            self.stderr.write('At least one comment is required')
+            return
         netiquette_url = ''
         organisation = comment.project.organisation
         if organisation.netiquette:
@@ -183,10 +188,27 @@ class Command(BaseCommand):
             module=comment.module,
             project=comment.project,
             netiquette_url=netiquette_url,
-            creator=self.user,
             receiver=[self.user],
             template_name=notification_emails.
             NotifyCreatorOnModeratorBlocked.template_name
+        )
+
+    def _send_notification_moderator_comment_statement(self):
+        # Send notification when moderator comment statement is added
+        statement = ModeratorCommentStatement.objects.first()
+        if not statement:
+            self.stderr.write(
+                'At least one moderator comment statement is required')
+            return
+        TestEmail.send(
+            statement,
+            project=statement.comment.project,
+            moderator_name=statement.creator.username,
+            moderator_statement=statement.statement,
+            comment_url=statement.comment.get_absolute_url(),
+            receiver=[self.user],
+            template_name=notification_emails.
+            NotifyCreatorOnModeratorCommentStatement.template_name
         )
 
     def _send_report_mails(self):

--- a/apps/userdashboard/api.py
+++ b/apps/userdashboard/api.py
@@ -76,12 +76,8 @@ class ModerationCommentViewSet(mixins.ListModelMixin,
         ).order_by('-created')
 
     def update(self, request, *args, **kwargs):
-        if 'is_blocked' in self.request.data:
-            comment = self.get_object()
-            comment.is_blocked = request.data['is_blocked']
-            comment.save()
-            if comment.is_blocked:
-                NotifyCreatorOnModeratorBlocked.send(comment)
+        if 'is_blocked' in self.request.data and request.data['is_blocked']:
+            NotifyCreatorOnModeratorBlocked.send(self.get_object())
         return super().update(request, *args, **kwargs)
 
     @action(detail=True)

--- a/tests/notifications/conftest.py
+++ b/tests/notifications/conftest.py
@@ -1,9 +1,13 @@
 from pytest_factoryboy import register
 
 from tests.budgeting.factories import ProposalFactory
+from tests.classifications.factories import AIClassificationFactory
 from tests.ideas.factories import IdeaFactory
+from tests.moderatorfeedback.factories import ModeratorCommentStatementFactory
 from tests.offlineevents.factories import OfflineEventFactory
 
 register(ProposalFactory)
+register(AIClassificationFactory)
 register(IdeaFactory)
+register(ModeratorCommentStatementFactory)
 register(OfflineEventFactory)

--- a/tests/notifications/test_creator_notifications.py
+++ b/tests/notifications/test_creator_notifications.py
@@ -87,3 +87,85 @@ def test_notify_creator_on_moderator_feedback(proposal_factory, client):
     assert mail.outbox[1].to[0] == creator.email
     assert mail.outbox[1].subject.startswith(
         'Feedback for your contribution')
+
+
+@pytest.mark.django_db
+def test_notify_comment_creator_on_block(
+        idea, comment_factory, apiclient, admin,
+        ai_classification_factory):
+    """Check if creator gets email on comment blocked."""
+    comment = comment_factory(content_object=idea)
+    ai_classification_factory(comment=comment)
+    creator = comment.creator
+    # FIXME: use moderator instead of admin when rules are there
+    # moderator = comment.project.moderators.first()
+
+    # 3 emails because of creator notification for reaction on idea
+    assert len(mail.outbox) == 3
+
+    url = reverse(
+        'moderationcomments-detail',
+        kwargs={
+            'project_pk': comment.project.pk,
+            'pk': comment.pk,
+        }
+    )
+    data = {
+        "is_blocked": True,
+    }
+
+    apiclient.force_authenticate(user=admin)
+    response = apiclient.patch(url, data, format='json')
+    assert response.status_code == 200
+    assert len(mail.outbox) == 4
+    assert mail.outbox[3].to[0] == creator.email
+    assert mail.outbox[3].subject.startswith(
+        'Your contribution was blocked')
+
+
+@pytest.mark.django_db
+def test_no_notify_comment_creator_on_unblock(
+        idea, comment_factory, apiclient, admin,
+        ai_classification_factory):
+    """Check creator gets no email on comment unblocked."""
+    comment = comment_factory(content_object=idea, is_blocked=True)
+    ai_classification_factory(comment=comment)
+    # FIXME: use moderator instead of admin when rules are there
+    # moderator = comment.project.moderators.first()
+
+    # 3 emails because of creator notification for reaction on idea
+    assert len(mail.outbox) == 3
+
+    url = reverse(
+        'moderationcomments-detail',
+        kwargs={
+            'project_pk': comment.project.pk,
+            'pk': comment.pk,
+        }
+    )
+    data = {
+        "is_blocked": False,
+    }
+
+    apiclient.force_authenticate(user=admin)
+    response = apiclient.patch(url, data, format='json')
+    assert response.status_code == 200
+    assert len(mail.outbox) == 3
+
+
+@pytest.mark.django_db
+def test_notify_comment_creator_on_feedback(
+        idea, comment_factory, moderator_comment_statement_factory):
+    """Check if creator gets email on comment statement added."""
+    comment = comment_factory(content_object=idea)
+    creator = comment.creator
+
+    # 3 emails because of creator notification for reaction on idea
+    assert len(mail.outbox) == 3
+
+    moderator_comment_statement_factory(comment=comment)
+
+    assert len(mail.outbox) == 4
+    assert mail.outbox[3].to[0] == creator.email
+    assert mail.outbox[3].subject.startswith(
+        'Feedback of the moderation')


### PR DESCRIPTION
In the test email command, the delete project email is broken. But that has to be fixed in a+. To test, just uncomment the broken email.

