### PR TITLE
[#5764] apps/userdashboard: utilize moderator_marked field for highlight

### DIFF
--- a/apps/userdashboard/api.py
+++ b/apps/userdashboard/api.py
@@ -82,6 +82,10 @@ class ModerationCommentViewSet(mixins.ListModelMixin,
             comment.save()
             if comment.is_blocked:
                 NotifyCreatorOnModeratorBlocked.send(comment)
+        elif 'is_moderator_marked' in self.request.data:
+            comment = self.get_object()
+            comment.is_moderator_marked = request.data['is_moderator_marked']
+            comment.save()
         return super().update(request, *args, **kwargs)
 
     @action(detail=True)


### PR DESCRIPTION
To test locally

- Get token using 

`curl -X POST http://localhost:8004/api/login/ -H 'Accept: application/json;' -d 'username=<username>&password=<password>'`
- Add token, project_pk and comment_pk to 

`curl -X PATCH http://localhost:8004/api/userdashboard/moderation/<project_pk>/comments/<comment_pk>/ -H 'Accept: application/json;' -H 'Authorization: Token <token>' -d 'is_moderator_marked=True'`
