### PR TITLE
DISCUSS: buttons/outline: show blue outline when using tab to navigate (note: …

### DIFF
--- a/adhocracy-plus/assets/scss/components/_button.scss
+++ b/adhocracy-plus/assets/scss/components/_button.scss
@@ -75,6 +75,11 @@
 .btn {
     @extend %button-base;
     @include button-color($link-color, $link-hover-color);
+
+    &:focus {
+        outline: 2px solid Highlight !important;
+        outline: 5px auto -webkit-focus-ring-color !important;
+    }
 }
 
 .btn--light {


### PR DESCRIPTION
…will show blue outline on mouse click as well)

Not sure if we want this, with this tabbing shows the blue outline, but on simple click it will show it as well. A11y in terms of semantic is given anyways because buttons.