### PR TITLE
settings/base: add setting to use comment.moderator_marked

### DIFF
--- a/adhocracy-plus/assets/scss/_variables.scss
+++ b/adhocracy-plus/assets/scss/_variables.scss
@@ -38,11 +38,10 @@ $dark:          $gray !default;
 
 $text-muted:    $text-color-gray !default;
 
-$blue-light: #d6eff9;
-$purple-light: #ecdbff;
-$purple-lighter: #ebe8ff; // classification: engaging
-$purple-lightest: #e7e7f1; // classification: ai
-$green-light: #e0fbe2;
+$blue-light: #d6eff9; // category: question
+$purple-light: #ebe8ff; // category: note, classification: engaging
+$purple-lighter: #e7e7f1; // classification: ai
+$green-light: #e0fbe2; //category: suggestion
 $red-light: #fce5e5; // classifiction: offensive
 $red-lighter: #fce5ec; // classifiction: fact claiming
 

--- a/adhocracy-plus/assets/scss/components/_a4-comments.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-comments.scss
@@ -25,6 +25,10 @@
 .a4-comments__comment {
     border-top: solid 1px $gray-lightest;
     padding: 1.5 * $spacer 0 $spacer 0;
+
+    mark > p {
+        background-color: $purple-light;
+    }
 }
 
 .a4-comments__box--left {
@@ -277,7 +281,7 @@
 }
 
 .a4-comments__badge[data-classification="engaging"] {
-    background-color: $purple-lighter;
+    background-color: $purple-light;
 }
 
 .a4-comments__badge[data-classification="fact claiming"] {
@@ -285,9 +289,10 @@
 }
 
 .a4-comments__badge[data-classification="ai"] {
-    background-color: $purple-lightest;
+    background-color: $purple-lighter;
 }
 
+// FIXME this should be a4-comments__text--linked but will need changing in multiple projects
 .a4-comments__text--highlighted {
     border-left: solid 2px $brand-primary;
     padding-left: 0.5 * $padding;

--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -543,7 +543,10 @@ SITE_ID = 1  # overwrite this in local.py if needed
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
+# Kosmo specific settings
+
 AI_API_AUTH_TOKEN = ''
 AI_API_URL = 'https://kosmo-api-dev.liqd.net/api/classify/'
 AI_USAGE = True
 AI_API_VERSION = '3.0'
+A4_COMMENTS_USE_MODERATOR_MARKED = True

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/liqd/adhocracy-plus.git",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
-    "adhocracy4": "git+https://github.com/liqd/adhocracy4#65d1f955e2646e67457cca44681d82ae37bceed1",
+    "adhocracy4": "git+https://github.com/liqd/adhocracy4#67f02d0e9bacab2003b6c6025dc6b2374ca3a7cc",
     "autoprefixer": "10.4.7",
     "bootstrap": "5.1.3",
     "css-loader": "6.7.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@65d1f955e2646e67457cca44681d82ae37bceed1#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@67f02d0e9bacab2003b6c6025dc6b2374ca3a7cc#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0


### PR DESCRIPTION
depends on https://github.com/liqd/adhocracy4/pull/1074

If A4_COMMENTS_USE_MODERATOR_MARKED is set to true, the highlighted option will appear in sorting filter of comments (and will also be default).

@phillimorland Probably styling can just go in here? Thank youuuu!