### PR TITLE
WIP apps/userdashboard/ModerationNotification.jsx: making german classifi…

### DIFF
--- a/adhocracy-plus/assets/scss/components/_a4-comments.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-comments.scss
@@ -275,15 +275,18 @@
     background-color: $green-light;
 }
 
-.a4-comments__badge[data-classification="offensive"] {
+.a4-comments__badge[data-classification="offensive"],
+.a4-comments__badge[data-classification="beleidigend"] {
     background-color: $red-light;
 }
 
-.a4-comments__badge[data-classification="engaging"] {
+.a4-comments__badge[data-classification="engaging"],
+.a4-comments__badge[data-classification="hochwertig"] {
     background-color: $purple-light;
 }
 
-.a4-comments__badge[data-classification="fact claiming"] {
+.a4-comments__badge[data-classification="fact claiming"],
+.a4-comments__badge[data-classification="tatsachenbehauptung"] {
     background-color: $red-lighter;
 }
 

--- a/apps/userdashboard/assets/js/a4_candy_userdashboard/ModerationNotification.jsx
+++ b/apps/userdashboard/assets/js/a4_candy_userdashboard/ModerationNotification.jsx
@@ -272,7 +272,7 @@ export const ModerationNotification = (props) => {
           {Object.entries(notification.category_counts).map((classification, i) => (
             <span
               className="badge a4-comments__badge a4-comments__badge--que"
-              data-classification={classification[0]}
+              data-classification={classification[0].toLowerCase()}
               key={i}
             >
               {`${classification[0]}: ${classification[1]}`}


### PR DESCRIPTION
…cations with color.

Better would be to receive a `type` or something on the endpoint, for instance:

```
category_counts: [
  { type: 'offensive', text: 'beleidigend', count: 1 },
  ...
]
```

so i do not have to rely on translated words. Would this be possible?
