### PR TITLE
userdashboard/api: use moderation_comment rules for OPTIONS request

### DIFF
--- a/apps/userdashboard/api.py
+++ b/apps/userdashboard/api.py
@@ -232,5 +232,6 @@ class ModerationCommentViewSet(mixins.ListModelMixin,
         return ViewSetRulesPermission.default_rules_method_map._replace(
             GET='a4_candy_userdashboard.view_moderation_comment',
             PUT='a4_candy_userdashboard.change_moderation_comment',
-            PATCH='a4_candy_userdashboard.change_moderation_comment'
+            PATCH='a4_candy_userdashboard.change_moderation_comment',
+            OPTIONS='a4_candy_userdashboard.view_moderation_comment'
         )


### PR DESCRIPTION
I forgot to overwrite permissions for OPTIONS requests, so it was throwing an error when not logged in as Admin and trying to access the userdashboard api, eg kosmo-dev.liqd.net/api/userdashboard/moderation/1/comments/49/userclassifications/ (Attention, this throws a 500 :)) So this fixes it.