### PR TITLE
[6268] apps/user: send send in blue welcome email after email confirm

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -560,3 +560,8 @@ AI_API_URL = 'https://kosmo-api-dev.liqd.net/api/classify/'
 AI_USAGE = True
 AI_API_VERSION = '3.0'
 A4_COMMENTS_USE_MODERATOR_MARKED = True
+
+SENDINBLUE_TEMPLATES = {
+    'en': 1,
+    'de': 3,
+}

--- a/apps/contrib/management/commands/send_test_emails.py
+++ b/apps/contrib/management/commands/send_test_emails.py
@@ -19,6 +19,7 @@ from apps.notifications import emails as notification_emails
 from apps.offlineevents.models import OfflineEvent
 from apps.projects import models as project_models
 from apps.users.emails import EmailAplus as Email
+from apps.users.emails import WelcomeEmail
 
 User = get_user_model()
 
@@ -80,6 +81,7 @@ class Command(BaseCommand):
         self._send_delete_project()
 
         self._send_form_mail()
+        self._send_welcome_email()
 
     def _send_notifications_create_idea(self):
         # Send notification for a newly created item
@@ -338,3 +340,7 @@ class Command(BaseCommand):
             template_name='a4_candy_cms_contacts/emails/answer_to_contact_form'
         )
         submission.delete()
+
+    def _send_welcome_email(self):
+        print('Sending send in blue welcome email')
+        WelcomeEmail.send(self.user)

--- a/apps/users/emails.py
+++ b/apps/users/emails.py
@@ -1,12 +1,18 @@
 from email.mime.image import MIMEImage
 
+import sib_api_v3_sdk
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.http import HttpResponse
 from django.template.loader import get_template
 from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import gettext_lazy as _
+from sentry_sdk import capture_exception
+from sib_api_v3_sdk.rest import ApiException
 
 from adhocracy4.emails import Email
+from adhocracy4.emails.mixins import SyncEmailMixin
 
 from .models import User
 
@@ -85,3 +91,65 @@ class EmailAplus(Email):
         link = link_text.format('<a href="' + self.get_host() + url
                                 + '" target="_blank">', '</a>')
         return link
+
+
+class WelcomeEmail(SyncEmailMixin, EmailAplus):
+
+    def get_receivers(self):
+        receiver = self.object
+        return [receiver]
+
+    def get_overview_link(self):
+        url = reverse('userdashboard-overview')
+        link = self.get_host() + url
+        return link
+
+    def get_template_id(self, receiver):
+        language = self.get_receiver_language(receiver)
+        try:
+            template_id = settings.SENDINBLUE_TEMPLATES[language]
+        except KeyError:
+            template_id = settings.SENDINBLUE_TEMPLATES[
+                settings.DEFAULT_USER_LANGUAGE_CODE
+            ]
+        return template_id
+
+    def dispatch(self, object, *args, **kwargs):
+        self.object = object
+        receiver = self.get_receivers()[0]
+
+        if (hasattr(settings, 'SENDINBLUE_API_KEY') and
+                hasattr(settings, 'SENDINBLUE_TEMPLATES')):
+            configuration = sib_api_v3_sdk.Configuration()
+            configuration.api_key['api-key'] = settings.SENDINBLUE_API_KEY
+
+            api_instance = sib_api_v3_sdk.TransactionalEmailsApi(
+                sib_api_v3_sdk.ApiClient(configuration)
+            )
+
+            to = [{"email": receiver.email, "NACHNAME": receiver.username}]
+            template_id = self.get_template_id(receiver)
+            params = {
+                "username": receiver.username,
+                "user_overview": self.get_overview_link(),
+            }
+            send_smtp_email = sib_api_v3_sdk.SendSmtpEmail(
+                to=to,
+                template_id=template_id,
+                params=params
+            )
+            try:
+                api_response = api_instance.send_transac_email(send_smtp_email)
+                if settings.DEBUG:
+                    print(api_response)
+                return HttpResponse(status=204)
+            except ApiException as e:
+                if settings.DEBUG:
+                    print("Exception when calling "
+                          "TransactionalEmailsApi->send_smtp_email: %s\n" % e)
+                else:
+                    capture_exception(e)
+        else:
+            raise ImproperlyConfigured(
+                'Please make sure SENDINBLUE_API_KEY and SENDINBLUE_TEMPLATES '
+                'are set in settings.')

--- a/apps/users/signals.py
+++ b/apps/users/signals.py
@@ -1,9 +1,12 @@
+from allauth.account.signals import email_confirmed
 from allauth.account.signals import user_signed_up
 from django.dispatch import receiver
 
 from adhocracy4.follows.models import Follow
 from adhocracy4.projects.models import Project
 from apps.cms.settings.models import OrganisationSettings
+
+from . import emails
 
 
 @receiver(user_signed_up)
@@ -16,3 +19,10 @@ def auto_follow_sample_project(request, user, **kwargs):
             Follow.objects.create(creator=user, project=sample_project)
         except Project.DoesNotExist:
             pass
+
+
+@receiver(email_confirmed)
+def send_welcome_email(request, email_address, **kwargs):
+    user = email_address.user
+    if user.emailaddress_set.all().count() == 1:
+        emails.WelcomeEmail.send(user)

--- a/requirements/fork.txt
+++ b/requirements/fork.txt
@@ -1,3 +1,4 @@
 # requirements needed in this fork, but not a+
 backoff==2.0.1
 httpx==0.22.0
+sib-api-v3-sdk==7.4.0

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -1,4 +1,5 @@
 import re
+from unittest.mock import patch
 
 import pytest
 from allauth.account.models import EmailAddress
@@ -57,7 +58,8 @@ def test_logout_with_next(user, client, logout_url):
 
 
 @pytest.mark.django_db
-def test_register(client, signup_url):
+@patch('apps.users.emails.WelcomeEmail.dispatch', return_value='/')
+def test_register(mock_provider, client, signup_url):
     assert EmailAddress.objects.count() == 0
     email = 'testuser@liqd.net'
     response = client.post(
@@ -95,7 +97,8 @@ def test_register(client, signup_url):
 
 
 @pytest.mark.django_db
-def test_register_with_next(client, signup_url):
+@patch('apps.users.emails.WelcomeEmail.dispatch', return_value='/')
+def test_register_with_next(mock_provider, client, signup_url):
     assert EmailAddress.objects.count() == 0
     email = 'testuser2@liqd.net'
     response = client.post(


### PR DESCRIPTION
When this is finished, I will fix the management command to send all emails again, but for now and for testing this is easier, because to test:
- add the api key to your local settings
- and use the management comand `send_test_emails`

`python manage.py send_test_emails <your_email>`

~~The email templates are a bit broken, though, and the link and actual username are only added to the English template. And there is a double greeting in the English one, because I could not get the `default` working with the params and for the contact I could only fill in the email on the api-call side.~~


To do:

- [x] only send to users confirming their first email
- [x] fix management command after reviewing
- [x] fix tests