### PR TITLE
[6275] templates/login: redirect to userdashboard overview when next is /

### DIFF
--- a/adhocracy-plus/templates/account/login.html
+++ b/adhocracy-plus/templates/account/login.html
@@ -18,7 +18,9 @@
             {% include 'a4_candy_contrib/includes/form_checkbox_field.html' with field=form.remember %}
         </div>
 
-        {% if redirect_field_value %}
+        {% if redirect_field_value == '/' %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{% url 'userdashboard-overview' %}"/>
+        {% elif redirect_field_value %}
             <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
         {% endif %}
 

--- a/adhocracy-plus/templates/account/signup.html
+++ b/adhocracy-plus/templates/account/signup.html
@@ -48,7 +48,9 @@
             </div>
             {{ form.get_newsletters.errors }}
         </div>
-        {% if redirect_field_value %}
+        {% if redirect_field_value == '/' %}
+            <input type="hidden" name="{{ redirect_field_name }}" value="{% url 'userdashboard-overview' %}"/>
+        {% elif redirect_field_value %}
             <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
         {% endif %}
 


### PR DESCRIPTION
I tried to add this into the [settings](https://github.com/liqd/a4-kosmo/blob/89e9a003cfd28c8daeb0766c72351eca46394fe8/adhocracy-plus/config/settings/base.py#L309) and the [python code](https://github.com/liqd/a4-kosmo/blob/89e9a003cfd28c8daeb0766c72351eca46394fe8/apps/users/templatetags/userindicator.py#L22), but could not make that work. This does. :woman_shrugging: 

- [x] Forgot the automatic login after email confirm during registration!