### PR TITLE
templates/footer: add kosmo specific styling

### DIFF
--- a/adhocracy-plus/assets/scss/components/_footer.scss
+++ b/adhocracy-plus/assets/scss/components/_footer.scss
@@ -21,6 +21,10 @@
     }
 }
 
+.footer__info-btn {
+    @extend .btn--text-color-inverted;
+}
+
 .footer__description {
     font-family: $font-family-serif;
 }

--- a/adhocracy-plus/templates/footer.html
+++ b/adhocracy-plus/templates/footer.html
@@ -18,12 +18,12 @@
                 <div class="row">
                 {% if pages.open_content_link %}
                 <div class="col-sm-6 d-flex flex-column">
-                    <a class="btn btn--secondary-transparent footer__info-btn" href="{{ pages.open_content_link }}">Open Content</a>
+                    <a class="btn btn--transparent footer__info-btn" href="{{ pages.open_content_link }}">Open Content</a>
                 </div>
                 {% endif %}
                 {% if pages.github_repo_link %}
                 <div class="col-sm-6 d-flex flex-column mt-4 mt-sm-0">
-                    <a class="btn btn--secondary-transparent footer__info-btn" href="{{ pages.github_repo_link }}">Open Source</a>
+                    <a class="btn btn--transparent footer__info-btn" href="{{ pages.github_repo_link }}">Open Source</a>
                 </div>
                 {% endif %}
                 </div>


### PR DESCRIPTION
Fixes #336  That was an older issue and only got worse with the rebase.
I did remove the extra button, we added during rebase (https://github.com/liqd/a4-kosmo/commit/8ca01b3a3eb5eae34d52ecfa94e7d5a16310b025#diff-53603775d3c1a341b05a8caf194b0ef031c0f5ad4acc0b044737a040aa8ec8f4R26) and used a class that was not used anywhere anyway to add the same styling as in the blocks (https://github.com/liqd/a4-kosmo/commit/8ca01b3a3eb5eae34d52ecfa94e7d5a16310b025#diff-338b0b18795691bbade12c9f7196b6e4f8595b440f930b49feb964ce7df2e0ebR151)